### PR TITLE
fix(lic): return false when numpoints is less than 3 (#60)

### DIFF
--- a/src/main/java/com/group12/LaunchInterceptorConditionCollection.java
+++ b/src/main/java/com/group12/LaunchInterceptorConditionCollection.java
@@ -55,8 +55,7 @@ public class LaunchInterceptorConditionCollection {
             throw new IllegalArgumentException("Points list cannot be null");
         }
         if (points.size() < 3) {
-            throw new IllegalArgumentException("There has to be at least three points, size of given points="
-                    + points.size());
+            return false;
         }
         if (doubleCompare(radius1, 0) < 0) {
             throw new IllegalArgumentException("Radius cannot be less than zero");
@@ -87,7 +86,7 @@ public class LaunchInterceptorConditionCollection {
             throw new IllegalArgumentException("Points list cannot be null");
         }
         if (points.size() < 3) {
-            throw new IllegalArgumentException("There has to be atleast three points");
+            return false;
         }
         if (doubleCompare(epsilon, 0) == -1 || doubleCompare(epsilon, PI) >= 0) {
             throw new IllegalArgumentException("Epsilon must hold these conditions: 0 <= Epsilon < Pi");
@@ -125,8 +124,7 @@ public class LaunchInterceptorConditionCollection {
             throw new IllegalArgumentException("Points list cannot be null");
         }
         if (points.size() < 3) {
-            throw new IllegalArgumentException("There has to be at least three points, size of given points="
-                    + points.size());
+            return false;
         }
         if (doubleCompare(area1, 0) < 0) {
             throw new IllegalArgumentException("Area cannot be less than zero");

--- a/src/test/java/com/group12/LaunchInterceptorConditionCollectionTest.java
+++ b/src/test/java/com/group12/LaunchInterceptorConditionCollectionTest.java
@@ -132,11 +132,13 @@ public class LaunchInterceptorConditionCollectionTest {
     }
 
     @Test
-    public void givenTwoPoint_whenLIC1_thenThrowIllegalArgumentException() {
+    public void givenTwoPoint_whenLIC1_thenFalse() {
         List<Point> points = List.of(new Point(2, 2), new Point(1, 1));
         double radius = 1;
 
-        assertThrows(IllegalArgumentException.class, () -> launchInterceptorConditionCollection.LIC1(points, radius));
+        boolean result = launchInterceptorConditionCollection.LIC1(points, radius);
+
+        assertFalse(result);
     }
 
     // Tests for LIC #2
@@ -170,11 +172,13 @@ public class LaunchInterceptorConditionCollectionTest {
     }
 
     @Test
-    public void givenInvalidAmountOfPointsAndValidDeviation_whenLIC2_thenThrowIllegalArgumentException(){
+    public void givenInvalidAmountOfPointsAndValidDeviation_whenLIC2_thenFalse(){
         List<Point> points = List.of(new Point(4, 0), new Point(0, 0));
         double epsilon = 2;
 
-        assertThrows(IllegalArgumentException.class, () -> launchInterceptorConditionCollection.LIC2(points,epsilon));
+        boolean result = launchInterceptorConditionCollection.LIC2(points, epsilon);
+
+        assertFalse(result);
     }
 
     @Test
@@ -260,11 +264,13 @@ public class LaunchInterceptorConditionCollectionTest {
     }
 
     @Test
-    public void givenTwoPoints_whenLIC3_thenThrowIllegalArgumentException() {
+    public void givenTwoPoints_whenLIC3_thenFalse() {
         List<Point> points = List.of(new Point(0, 0), new Point(0, 2));
         double area = 1;
 
-        assertThrows(IllegalArgumentException.class, () -> launchInterceptorConditionCollection.LIC3(points, area));
+        boolean result = launchInterceptorConditionCollection.LIC3(points, area);
+
+        assertFalse(result);
     }
 
     // Tests for LIC #4


### PR DESCRIPTION
LIC 1, 2 and 3 was throwing an IllegalArgumentException when the number
of points was less than 3 which they shouldn't. Instead they should
return false since 2 points is a valid input to the program but not
enough for the LICs, hence the conditions are not met and they should
return false.

Fixes #60 